### PR TITLE
Box create/ensure now takes a parameter hash.

### DIFF
--- a/lib/vagrant_cloud/account.rb
+++ b/lib/vagrant_cloud/account.rb
@@ -96,10 +96,10 @@ module VagrantCloud
       # This could easily be changed to merge all hashes in *args if
       # necessary.
       params = args.select { |v| v.is_a?(Hash) }.first
-      if params.is_a?(Hash)
-        args.delete_if { |v| v == params }
-      else
+      if params.nil?
         params = {}
+      else
+        args.delete_if { |v| v == params }
       end
 
       # Description should be the first item that's left in *args, if nothing

--- a/lib/vagrant_cloud/account.rb
+++ b/lib/vagrant_cloud/account.rb
@@ -85,6 +85,10 @@ module VagrantCloud
     # @param [Array] args
     # @return [Hash]
     def box_params(*args)
+      # Prepares a hash based on the *args array passed in.
+      # Acceptable parameters are those documented by Hashicorp for the v1 API
+      # at https://atlas.hashicorp.com/docs
+
       # This dance is to simulate what we could have accomplished with **args
       # in Ruby 2.0+
       # This will silently discard any options that are not passed in as a

--- a/lib/vagrant_cloud/account.rb
+++ b/lib/vagrant_cloud/account.rb
@@ -29,8 +29,10 @@ module VagrantCloud
 
       # If description is provided, it will override the params entry.
       # This is provided for backwards compatibility.
-      params[:description] = description unless description.nil?
-      params[:short_description] = description unless description.nil?
+      unless description.nil?
+        params[:description] = description
+        params[:short_description] = description
+      end
 
       # Default boxes to public can be overridden by providing :is_private
       params[:is_private] = false unless defined? params[:is_private]

--- a/lib/vagrant_cloud/account.rb
+++ b/lib/vagrant_cloud/account.rb
@@ -20,7 +20,7 @@ module VagrantCloud
     end
 
     # @param [String] name
-    # @param [Hash] params
+    # @param [Hash] args
     # @return [Box]
     def create_box(name, *args)
       params = box_params(*args)

--- a/lib/vagrant_cloud/account.rb
+++ b/lib/vagrant_cloud/account.rb
@@ -23,7 +23,7 @@ module VagrantCloud
     # @param [String] description
     # @param [Hash] params
     # @return [Box]
-    def create_box(name, description = nil, params: {})
+    def create_box(name, description = nil, **params)
       fail "Parameters must be a hash" unless params.is_a?(Hash)
       params[:name] = name
 
@@ -43,7 +43,7 @@ module VagrantCloud
     # @param [String] description
     # @param [Hash] params
     # @return [Box]
-    def ensure_box(name, description = nil, params: {})
+    def ensure_box(name, description = nil, **params)
       fail "Parameters must be a hash" unless params.is_a?(Hash)
 
       # If description is provided, it will override the params entry.

--- a/lib/vagrant_cloud/account.rb
+++ b/lib/vagrant_cloud/account.rb
@@ -31,7 +31,7 @@ module VagrantCloud
     end
 
     # @param [String] name
-    # @param [Hash] params
+    # @param [Hash] args
     # @return [Box]
     def ensure_box(name, *args)
       params = box_params(*args)

--- a/lib/vagrant_cloud/account.rb
+++ b/lib/vagrant_cloud/account.rb
@@ -20,35 +20,39 @@ module VagrantCloud
     end
 
     # @param [String] name
-    # @param [String] description
-    # @param [TrueClass, FalseClass] is_private
+    # @param [Hash] params
     # @return [Box]
-    def create_box(name, description = nil, is_private = false)
-      params = {:name => name}
-      params[:description] = description if description
-      params[:short_description] = description if description
-      params[:is_private] = is_private
+    def create_box(name, params = {})
+      fail "Parameters must be a hash" unless params.is_a?(Hash)
+      params[:name] = name
+      params[:is_private] = 0 unless defined? params[:is_private]
       data = request('post', '/boxes', {:box => params})
       get_box(name, data)
     end
 
     # @param [String] name
-    # @param [String] description
-    # @param [TrueClass, FalseClass] is_private
+    # @param [Hash] params
     # @return [Box]
-    def ensure_box(name, description = nil, is_private = nil)
+    def ensure_box(name, params = {})
+      fail "Parameters must be a hash" unless params.is_a?(Hash)
       begin
         box = get_box(name)
         box.data
       rescue RestClient::ResourceNotFound => e
-        box = create_box(name, description, is_private)
+        box = create_box(name, extras)
+        # If we've just created the box, we're done.
+        return box
       end
 
-      updated_description = (!description.nil? && (description != box.description || description != box.description_short))
-      updated_private = (!is_private.nil? && (is_private != box.private))
-      if updated_description || updated_private
-        box.update(description, is_private)
-      end
+      # If params is empty, there's nothing to update.
+      return box if params.empty?
+
+      # Select elements from params that don't match what we have in the box
+      # data. These are changed parameters and should be updated.
+      update_params = params.select { |k,v| box.data[k] != v }
+
+      # Update the box with any params that had changed.
+      box.update(update_params) unless update_params.empty?
 
       box
     end

--- a/lib/vagrant_cloud/account.rb
+++ b/lib/vagrant_cloud/account.rb
@@ -48,8 +48,10 @@ module VagrantCloud
 
       # If description is provided, it will override the params entry.
       # This is provided for backwards compatibility.
-      params[:description] = description unless description.nil?
-      params[:short_description] = description unless description.nil?
+      unless description.nil?
+        params[:description] = description
+        params[:short_description] = description
+      end
 
       begin
         box = get_box(name)
@@ -66,7 +68,7 @@ module VagrantCloud
       # Select elements from params that don't match what we have in the box
       # data. These are changed parameters and should be updated.
       update_params = params.select { |k,v|
-	box.data[box.param_name(k)] != v
+        box.data[box.param_name(k)] != v
       }
 
       # Update the box with any params that had changed.

--- a/lib/vagrant_cloud/account.rb
+++ b/lib/vagrant_cloud/account.rb
@@ -45,9 +45,6 @@ module VagrantCloud
         return box
       end
 
-      # If params is empty, there's nothing to update.
-      return box if params.empty?
-
       # Select elements from params that don't match what we have in the box
       # data. These are changed parameters and should be updated.
       update_params = params.select { |k,v|

--- a/lib/vagrant_cloud/account.rb
+++ b/lib/vagrant_cloud/account.rb
@@ -87,26 +87,15 @@ module VagrantCloud
     def box_params(*args)
       # This dance is to simulate what we could have accomplished with **args
       # in Ruby 2.0+
+      # This will silently discard any options that are not passed in as a
+      # hash.
       # Find and remove the first hash we find in *args. Set params to an
       # empty hash if we weren't passed one.
-      # This could easily be changed to merge all hashes in *args if
-      # necessary.
       params = args.select { |v| v.is_a?(Hash) }.first
       if params.nil?
         params = {}
       else
         args.delete_if { |v| v == params }
-      end
-
-      # Description should be the first item that's left in *args, if nothing
-      # is left (we were only passed a hash), this will return nil.
-      description = args.first
-
-      # If description is provided, it will override the params entry.
-      # This is provided for backwards compatibility.
-      unless description.nil?
-        params[:description] = description
-        params[:short_description] = description
       end
 
       # Default boxes to public can be overridden by providing :is_private

--- a/lib/vagrant_cloud/account.rb
+++ b/lib/vagrant_cloud/account.rb
@@ -39,7 +39,7 @@ module VagrantCloud
         box = get_box(name)
         box.data
       rescue RestClient::ResourceNotFound => e
-        box = create_box(name, extras)
+        box = create_box(name, params)
         # If we've just created the box, we're done.
         return box
       end

--- a/lib/vagrant_cloud/account.rb
+++ b/lib/vagrant_cloud/account.rb
@@ -20,7 +20,7 @@ module VagrantCloud
     end
 
     # @param [String] name
-    # @param [Array] params
+    # @param [Hash] params
     # @return [Box]
     def create_box(name, *args)
       params = box_params(*args)
@@ -31,7 +31,6 @@ module VagrantCloud
     end
 
     # @param [String] name
-    # @param [String] description
     # @param [Hash] params
     # @return [Box]
     def ensure_box(name, *args)

--- a/lib/vagrant_cloud/box.rb
+++ b/lib/vagrant_cloud/box.rb
@@ -81,5 +81,19 @@ module VagrantCloud
       version
     end
 
+    def param_name(param)
+      # This needs to return strings, otherwise it won't match the JSON that
+      # Vagrant Cloud returns.
+      ATTR_MAP.fetch(param, param.to_s)
+    end
+
+    private
+
+    # Vagrant Cloud returns keys different from what you set for some params.
+    # Values in this map should be strings.
+    ATTR_MAP = {
+      :is_private  => 'private',
+      :description => 'description_markdown',
+    }
   end
 end

--- a/lib/vagrant_cloud/box.rb
+++ b/lib/vagrant_cloud/box.rb
@@ -81,6 +81,8 @@ module VagrantCloud
       version
     end
 
+    # @param [Symbol]
+    # @return [String]
     def param_name(param)
       # This needs to return strings, otherwise it won't match the JSON that
       # Vagrant Cloud returns.

--- a/lib/vagrant_cloud/box.rb
+++ b/lib/vagrant_cloud/box.rb
@@ -41,14 +41,8 @@ module VagrantCloud
       @data ||= account.request('get', "/box/#{account.username}/#{name}")
     end
 
-    # @param [String] description
-    # @param [TrueClass, FalseClass] is_private
-    def update(description, is_private)
-      box = {
-        :short_description => description,
-        :description => description,
-        :is_private => is_private,
-      }
+    # @param [Hash] box
+    def update(box = {})
       @data = account.request('put', "/box/#{account.username}/#{name}", {:box => box})
     end
 

--- a/lib/vagrant_cloud/box.rb
+++ b/lib/vagrant_cloud/box.rb
@@ -42,8 +42,8 @@ module VagrantCloud
     end
 
     # @param [Hash] box
-    def update(box = {})
-      @data = account.request('put', "/box/#{account.username}/#{name}", {:box => box})
+    def update(args = {})
+      @data = account.request('put', "/box/#{account.username}/#{name}", {:box => args})
     end
 
     def delete

--- a/lib/vagrant_cloud/box.rb
+++ b/lib/vagrant_cloud/box.rb
@@ -41,7 +41,7 @@ module VagrantCloud
       @data ||= account.request('get', "/box/#{account.username}/#{name}")
     end
 
-    # @param [Hash] box
+    # @param [Hash] args
     def update(args = {})
       @data = account.request('put', "/box/#{account.username}/#{name}", {:box => args})
     end

--- a/spec/vagrant_cloud/account_spec.rb
+++ b/spec/vagrant_cloud/account_spec.rb
@@ -56,7 +56,9 @@ module VagrantCloud
               }
             }).to_return(status: 200, body: JSON.dump(result))
 
-        box = account.create_box('my-name', 'my-desc', true)
+        box = account.create_box('my-name', 'my-desc', params: {
+                                :is_private => true,
+        })
         expect(box).to be_a(Box)
         expect(box.data).to eq(result)
       end
@@ -73,9 +75,15 @@ module VagrantCloud
             'private' => true,
           })
         expect(account).to receive(:get_box).with('foo').and_return(box_requested)
-        expect(account).to receive(:create_box).with('foo', 'desc', true).and_return(box_created)
+        expect(account).to receive(:create_box).with('foo', {
+            :description => 'desc',
+            :short_description => 'desc',
+            :is_private => true,
+        }).and_return(box_created)
 
-        box = account.ensure_box('foo', 'desc', true)
+        box = account.ensure_box('foo', 'desc', params: {
+                                :is_private => true,
+        })
         expect(box).to eq(box_created)
       end
 
@@ -87,7 +95,9 @@ module VagrantCloud
           })
         expect(account).to receive(:get_box).with('foo').and_return(box_requested)
 
-        box = account.ensure_box('foo', 'desc', true)
+        box = account.ensure_box('foo', 'desc', params: {
+                                :is_private => true,
+        })
         expect(box).to eq(box_requested)
       end
 
@@ -98,9 +108,14 @@ module VagrantCloud
             'private' => true,
           })
         expect(account).to receive(:get_box).with('foo').and_return(box_requested)
-        expect(box_requested).to receive(:update).with('desc', true)
+        expect(box_requested).to receive(:update).with({
+            :description => 'desc',
+            :short_description => 'desc',
+        })
 
-        box = account.ensure_box('foo', 'desc', true)
+        box = account.ensure_box('foo', 'desc', params: {
+                                :is_private => true,
+        })
         expect(box).to eq(box_requested)
       end
     end

--- a/spec/vagrant_cloud/account_spec.rb
+++ b/spec/vagrant_cloud/account_spec.rb
@@ -56,9 +56,9 @@ module VagrantCloud
               }
             }).to_return(status: 200, body: JSON.dump(result))
 
-        box = account.create_box('my-name', 'my-desc', params: {
-                                :is_private => true,
-        })
+        box = account.create_box('my-name', 'my-desc',
+            :is_private => true,
+        )
         expect(box).to be_a(Box)
         expect(box.data).to eq(result)
       end
@@ -81,9 +81,9 @@ module VagrantCloud
             :is_private => true,
         }).and_return(box_created)
 
-        box = account.ensure_box('foo', 'desc', params: {
-                                :is_private => true,
-        })
+        box = account.ensure_box('foo', 'desc',
+            :is_private => true,
+        )
         expect(box).to eq(box_created)
       end
 
@@ -95,9 +95,9 @@ module VagrantCloud
           })
         expect(account).to receive(:get_box).with('foo').and_return(box_requested)
 
-        box = account.ensure_box('foo', 'desc', params: {
-                                :is_private => true,
-        })
+        box = account.ensure_box('foo', 'desc',
+            :is_private => true,
+        )
         expect(box).to eq(box_requested)
       end
 
@@ -113,9 +113,9 @@ module VagrantCloud
             :short_description => 'desc',
         })
 
-        box = account.ensure_box('foo', 'desc', params: {
-                                :is_private => true,
-        })
+        box = account.ensure_box('foo', 'desc',
+            :is_private => true,
+        )
         expect(box).to eq(box_requested)
       end
     end

--- a/spec/vagrant_cloud/account_spec.rb
+++ b/spec/vagrant_cloud/account_spec.rb
@@ -56,7 +56,9 @@ module VagrantCloud
               }
             }).to_return(status: 200, body: JSON.dump(result))
 
-        box = account.create_box('my-name', 'my-desc',
+        box = account.create_box('my-name',
+            :description => 'my-desc',
+            :short_description => 'my-desc',
             :is_private => true,
         )
         expect(box).to be_a(Box)
@@ -81,7 +83,9 @@ module VagrantCloud
             :is_private => true,
         }).and_return(box_created)
 
-        box = account.ensure_box('foo', 'desc',
+        box = account.ensure_box('foo',
+            :description => 'desc',
+            :short_description => 'desc',
             :is_private => true,
         )
         expect(box).to eq(box_created)
@@ -95,7 +99,9 @@ module VagrantCloud
           })
         expect(account).to receive(:get_box).with('foo').and_return(box_requested)
 
-        box = account.ensure_box('foo', 'desc',
+        box = account.ensure_box('foo',
+            :description => 'desc',
+            :short_description => 'desc',
             :is_private => true,
         )
         expect(box).to eq(box_requested)
@@ -113,7 +119,9 @@ module VagrantCloud
             :short_description => 'desc',
         })
 
-        box = account.ensure_box('foo', 'desc',
+        box = account.ensure_box('foo',
+            :description => 'desc',
+            :short_description => 'desc',
             :is_private => true,
         )
         expect(box).to eq(box_requested)

--- a/spec/vagrant_cloud/box_spec.rb
+++ b/spec/vagrant_cloud/box_spec.rb
@@ -57,7 +57,11 @@ module VagrantCloud
         ).to_return(status: 200, body: JSON.dump(result))
 
         box = Box.new(account, 'foo')
-        box.update('my-desc', true)
+        box.update({
+            :description => 'my-desc',
+            :short_description => 'my-desc',
+            :is_private => true,
+        })
 
         expect(box.data).to eq(result)
       end


### PR DESCRIPTION
Boxes have a few attributes. Not all of these were supported by
vagrant_cloud. This commit makes the box functions work with any number
of attributes.

This should also ensure that box.update is called if any given parameter differs from what already exists on the box.

This approach hasn't been applied to API areas other than boxes, since those other areas currently only have a single optional argument each.