### PR TITLE
Newly created box is private

### DIFF
--- a/lib/vagrant_cloud/account.rb
+++ b/lib/vagrant_cloud/account.rb
@@ -103,7 +103,7 @@ module VagrantCloud
       end
 
       # Default boxes to public can be overridden by providing :is_private
-      params[:is_private] = false unless defined? params[:is_private]
+      params[:is_private] = false unless params.has_key?(:is_private)
 
       params
     end

--- a/spec/vagrant_cloud/account_spec.rb
+++ b/spec/vagrant_cloud/account_spec.rb
@@ -64,6 +64,25 @@ module VagrantCloud
         expect(box).to be_a(Box)
         expect(box.data).to eq(result)
       end
+
+      context 'when not passing :is_private' do
+        it 'creates a public box' do
+          result = {'return_foo' => 'foo'}
+          stub_request(:post, 'https://atlas.hashicorp.com/api/v1/boxes').with(:body =>
+             {
+               :access_token => 'my-token',
+               :box => {
+                 :name => 'my-name',
+                 :description => 'my-desc',
+                 :is_private => 'false',
+               }
+             }).to_return(status: 200, body: JSON.dump(result))
+
+          box = account.create_box('my-name', :description => 'my-desc')
+          expect(box).to be_a(Box)
+          expect(box.data).to eq(result)
+        end
+      end
     end
 
     describe '.ensure_box' do

--- a/vagrant_cloud.gemspec
+++ b/vagrant_cloud.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'vagrant_cloud'
-  s.version     = '0.4.0'
+  s.version     = '0.4.1'
   s.summary     = 'HashiCorp Atlas API client'
   s.description = 'Minimalistic ruby client for the HashiCorp Atlas API (previously Vagrant Cloud API)'
   s.authors     = ['Cargo Media']


### PR DESCRIPTION
The debian 8 boxes I pushed were private.

<img width="317" alt="screen shot 2016-01-28 at 15 59 39" src="https://cloud.githubusercontent.com/assets/1888714/12648014/37116c70-c5d8-11e5-983a-8e40eeea4cab.png">


This shouldn't be according to
https://github.com/cargomedia/vagrant_cloud/blob/415510bb5d4a22d9a454fda70d68918d110e5c20/lib/vagrant_cloud/account.rb#L106

@njam @tomaszdurka correct me if wrong?

