### PR TITLE
Added ruby 2.3 and ruby 2.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ sudo: false
 rvm:
   - 2.1
   - 2.2
+  - 2.3.4
+  - 2.4.1
 
 install:
   - bundle install

--- a/README.md
+++ b/README.md
@@ -21,3 +21,12 @@ provider = version.ensure_provider('virtualbox', 'http://example.com/foo.box')
 version.release
 puts provider.download_url
 ```
+
+Development & Contributing
+--------------------------
+Pull requests are very welcome! Please try to follow these simple rules if applicable:
+
+* Make sure you run `bundle exec rspec` before creating a pull request.  all specs must pass and all new code needs test coverage
+* Run `rubocop` locally before pulling
+* Update the README as appropriate
+* Please do not change the version number.

--- a/vagrant_cloud.gemspec
+++ b/vagrant_cloud.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake', '~> 10.4'
   s.add_development_dependency 'rspec', '~> 3.0'
-  s.add_development_dependency 'webmock', '~> 1.21'
+  s.add_development_dependency 'webmock', '~> 3.0'
   s.add_development_dependency 'rubocop', '~> 0.41.2'
 end


### PR DESCRIPTION
previously, ruby 2.4 rspecs wouldn't run, due to some changes to Net::HTTP, I presume;  updating WebMock to a current version (3.x) resolves this and is backwards compatible to ruby 2.1