### PR TITLE
created provider.upload_file method; added a CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ puts provider.download_url
 ```
 
 Example CLI usage:
+Create a version and provider within an existing Box, upload a file to be hosted by Vagrant/Atlas, and release the version
 ```sh
 vagrant_cloud create_version --username $USERNAME --token $VAGRANT_CLOUD_TOKEN --box $BOX_NAME --version $BOX_VERSION
 vagrant_cloud create_provider --username $USERNAME --token $VAGRANT_CLOUD_TOKEN --box $BOX_NAME --version $BOX_VERSION
 vagrant_cloud upload_file --username $USERNAME --token $VAGRANT_CLOUD_TOKEN --box $BOX_NAME --version $BOX_VERSION --provider_file_path $PACKAGE_PATH
+vagrant_cloud release_version --username $USERNAME --token $VAGRANT_CLOUD_TOKEN --box $BOX_NAME --version $BOX_VERSION
 ```
 If you installed vagrant_cloud with bundler, then you may have to invoke using `bundle exec vagrant_cloud`
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ version.release
 puts provider.download_url
 ```
 
+Example CLI usage:
+```sh
+vagrant_cloud create_version --username $USERNAME --token $VAGRANT_CLOUD_TOKEN --box $BOX_NAME --version $BOX_VERSION
+vagrant_cloud create_provider --username $USERNAME --token $VAGRANT_CLOUD_TOKEN --box $BOX_NAME --version $BOX_VERSION
+vagrant_cloud upload_file --username $USERNAME --token $VAGRANT_CLOUD_TOKEN --box $BOX_NAME --version $BOX_VERSION --provider_file_path $PACKAGE_PATH
+```
+If you installed vagrant_cloud with bundler, then you may have to invoke using `bundle exec vagrant_cloud`
+
 Development & Contributing
 --------------------------
 Pull requests are very welcome! Please try to follow these simple rules if applicable:

--- a/bin/vagrant_cloud
+++ b/bin/vagrant_cloud
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require 'vagrant_cloud'
+
+VagrantCloud::Cli.start(ARGV)

--- a/lib/vagrant_cloud.rb
+++ b/lib/vagrant_cloud.rb
@@ -6,4 +6,5 @@ module VagrantCloud
   require 'vagrant_cloud/box'
   require 'vagrant_cloud/version'
   require 'vagrant_cloud/provider'
+  require 'vagrant_cloud/cli'
 end

--- a/lib/vagrant_cloud/cli.rb
+++ b/lib/vagrant_cloud/cli.rb
@@ -23,6 +23,7 @@ module VagrantCloud
     desc 'release_version', 'release the specified version within a given box'
     def release_version(version_str = options[:version])
       version = current_box.get_version(version_str)
+      version.release
       puts "Box #{options[:box]} / version: #{versoin.version}; current status is #{version.status}" if options[:verbose]
       true
     end

--- a/lib/vagrant_cloud/cli.rb
+++ b/lib/vagrant_cloud/cli.rb
@@ -4,47 +4,44 @@ module VagrantCloud
   class Cli < Thor
     package_name 'VagrantCloud'
 
-    class_option :username, alias: '-u', desc: 'Vagrant Cloud username'
-    class_option :token, alias: '-t', desc: 'Vagrant Cloud access token'
-    class_option :box, alias: '-b', desc: 'name of the box'
-    class_option :version, alias: '-v', desc: 'version within the box'
-    class_option :provider, alias: '-p', default: 'virtualbox', desc: 'the provider for the box; default: virtualbox'
-    class_option :provider_url, alias: '-pu', desc: 'URL to the file for remote hosting; either a _url or _file_path can be provided, not both'
-    class_option :provider_file_path, alias: '-pfp', desc: 'path to file to be uploaded for Atlast hosting'
+    class_option :username, alias: '-u', required: true, desc: 'Vagrant Cloud username'
+    class_option :token, alias: '-t', required: true, desc: 'Vagrant Cloud access token'
+    class_option :box, alias: '-b', required: true, desc: 'name of the box'
     class_option :verbose, type: :boolean
 
     desc 'create_version', 'creates a new version within a given box'
-    def create_version(version_str = options[:version])
-      version = current_box.create_version(version_str)
+    method_option :version, alias: '-v', required: true, desc: 'version within the box'
+    def create_version
+      version = current_box.create_version(options[:version])
       puts "created #{version.version} of box #{options[:box]}; current status is #{version.status}" if options[:verbose]
       version
     end
 
     desc 'release_version', 'release the specified version within a given box'
-    def release_version(version_str = options[:version])
-      version = current_box.get_version(version_str)
+    method_option :version, alias: '-v', required: true, desc: 'version within the box'
+    def release_version
+      version = get_version(options[:version])
       version.release
       puts "Box #{options[:box]} / version: #{versoin.version}; current status is #{version.status}" if options[:verbose]
       true
     end
 
     desc 'create_provider', 'creates a provider within a given box and version'
+    method_option :version, alias: '-v', required: true, desc: 'version within the box'
+    method_option :provider, alias: '-p', default: 'virtualbox', desc: 'the provider for the box; default: virtualbox'
+    method_option :provider_url, alias: '-pu', desc: 'URL to the file for remote hosting; either a _url or _file_path can be provided, not both'
     def create_provider
-      provider = current_version.create_provider(options[:provider], options[:provider_url])
+      provider = get_version(options[:version]).create_provider(options[:provider], options[:provider_url])
       puts "created #{provider.data['name']} provider within version #{provider.version.version}" if options[:verbose]
       provider
     end
 
-    desc 'versions', 'list all the versions of a given box'
-    def versions
-      box = current_box
-      puts box.versions if options[:verbose]
-      box.versions
-    end
-
     desc 'upload_file', 'upload a given file for Atlas to host to an existing version and provider'
+    method_option :version, alias: '-v', required: true, desc: 'version within the box'
+    method_option :provider, alias: '-p', default: 'virtualbox', desc: 'the provider for the box; default: virtualbox'
+    method_option :provider_file_path, alias: '-pfp', required: true, desc: 'path to file to be uploaded for Atlast hosting'
     def upload_file
-      provider = current_version.get_provider(options[:provider])
+      provider = get_version(options[:version]).get_provider(options[:provider])
       provider.upload_file(options[:provider_file_path])
     end
 
@@ -58,8 +55,8 @@ module VagrantCloud
       current_account.get_box(options[:box])
     end
 
-    def current_version
-      current_box.get_version(options[:version])
+    def get_version(version_str)
+      current_box.get_version(version_str)
     end
 
     def bump_version(version_str)

--- a/lib/vagrant_cloud/cli.rb
+++ b/lib/vagrant_cloud/cli.rb
@@ -1,0 +1,63 @@
+require 'thor'
+
+module VagrantCloud
+  class Cli < Thor
+    package_name 'VagrantCloud'
+
+    class_option :username, alias: '-u', desc: 'Vagrant Cloud username'
+    class_option :token, alias: '-t', desc: 'Vagrant Cloud access token'
+    class_option :box, alias: '-b', desc: 'name of the box'
+    class_option :version, alias: '-v', desc: 'version within the box'
+    class_option :provider, alias: '-p', default: 'virtualbox', desc: 'the provider for the box; default: virtualbox'
+    class_option :provider_url, alias: '-pu', desc: 'URL to the file for remote hosting; either a _url or _file_path can be provided, not both'
+    class_option :provider_file_path, alias: '-pfp', desc: 'path to file to be uploaded for Atlast hosting'
+    class_option :verbose, type: :boolean
+
+    desc 'create_version', 'creates a new version within a given box'
+    def create_version(version_str = options[:version])
+      version = current_box.create_version(version_str)
+      puts "created #{version.version} of box #{options[:box]}; current status is #{version.status}" if options[:verbose]
+      version
+    end
+
+    desc 'create_provider', 'creates a provider within a given box and version'
+    def create_provider
+      provider = current_version.create_provider(options[:provider], options[:provider_url])
+      puts "created #{provider.data['name']} provider within version #{provider.version.version}" if options[:verbose]
+      provider
+    end
+
+    desc 'versions', 'list all the versions of a given box'
+    def versions
+      box = current_box
+      puts box.versions if options[:verbose]
+      box.versions
+    end
+
+    desc 'upload_file', 'upload a given file for Atlas to host to an existing version and provider'
+    def upload_file
+      provider = current_version.get_provider(options[:provider])
+      provider.upload_file(options[:provider_file_path])
+    end
+
+    private
+
+    def current_account
+      VagrantCloud::Account.new(options[:username], options[:token])
+    end
+
+    def current_box
+      current_account.get_box(options[:box])
+    end
+
+    def current_version
+      current_box.get_version(options[:version])
+    end
+
+    def bump_version(version_str)
+      parts = version_str.split('.')
+      parts.push(parts.pop.to_i + 1)
+      parts.join('.')
+    end
+  end
+end

--- a/lib/vagrant_cloud/cli.rb
+++ b/lib/vagrant_cloud/cli.rb
@@ -20,6 +20,13 @@ module VagrantCloud
       version
     end
 
+    desc 'release_version', 'release the specified version within a given box'
+    def release_version(version_str = options[:version])
+      version = current_box.get_version(version_str)
+      puts "Box #{options[:box]} / version: #{versoin.version}; current status is #{version.status}" if options[:verbose]
+      true
+    end
+
     desc 'create_provider', 'creates a provider within a given box and version'
     def create_provider
       provider = current_version.create_provider(options[:provider], options[:provider_url])

--- a/lib/vagrant_cloud/cli.rb
+++ b/lib/vagrant_cloud/cli.rb
@@ -20,9 +20,9 @@ module VagrantCloud
     desc 'release_version', 'release the specified version within a given box'
     method_option :version, alias: '-v', required: true, desc: 'version within the box'
     def release_version
-      version = get_version(options[:version])
+      version = current_version
       version.release
-      puts "Box #{options[:box]} / version: #{versoin.version}; current status is #{version.status}" if options[:verbose]
+      puts "Box #{options[:box]} / version: #{version.version}; current status is #{version.status}" if options[:verbose]
       true
     end
 
@@ -31,18 +31,17 @@ module VagrantCloud
     method_option :provider, alias: '-p', default: 'virtualbox', desc: 'the provider for the box; default: virtualbox'
     method_option :provider_url, alias: '-pu', desc: 'URL to the file for remote hosting; either a _url or _file_path can be provided, not both'
     def create_provider
-      provider = get_version(options[:version]).create_provider(options[:provider], options[:provider_url])
+      provider = current_version.create_provider(options[:provider], options[:provider_url])
       puts "created #{provider.data['name']} provider within version #{provider.version.version}" if options[:verbose]
       provider
     end
 
-    desc 'upload_file', 'upload a given file for Atlas to host to an existing version and provider'
+    desc 'upload_file', 'upload a file for Atlas to host to an existing version and provider'
     method_option :version, alias: '-v', required: true, desc: 'version within the box'
     method_option :provider, alias: '-p', default: 'virtualbox', desc: 'the provider for the box; default: virtualbox'
     method_option :provider_file_path, alias: '-pfp', required: true, desc: 'path to file to be uploaded for Atlast hosting'
     def upload_file
-      provider = get_version(options[:version]).get_provider(options[:provider])
-      provider.upload_file(options[:provider_file_path])
+      get_provider(options[:provider]).upload_file(options[:provider_file_path])
     end
 
     private
@@ -55,8 +54,12 @@ module VagrantCloud
       current_account.get_box(options[:box])
     end
 
-    def get_version(version_str)
-      current_box.get_version(version_str)
+    def current_version
+      current_box.get_version(options[:version])
+    end
+
+    def get_provider(provider_str)
+      current_version.get_provider(provider_str)
     end
 
     def bump_version(version_str)

--- a/lib/vagrant_cloud/cli.rb
+++ b/lib/vagrant_cloud/cli.rb
@@ -29,7 +29,7 @@ module VagrantCloud
     desc 'create_provider', 'creates a provider within a given box and version'
     method_option :version, alias: '-v', required: true, desc: 'version within the box'
     method_option :provider, alias: '-p', default: 'virtualbox', desc: 'the provider for the box; default: virtualbox'
-    method_option :provider_url, alias: '-pu', desc: 'URL to the file for remote hosting; either a _url or _file_path can be provided, not both'
+    method_option :provider_url, alias: '-pu', desc: 'URL to the file for remote hosting; do not include if you intend to upload a file subsequently'
     def create_provider
       provider = current_version.create_provider(options[:provider], options[:provider_url])
       puts "created #{provider.data['name']} provider within version #{provider.version.version}" if options[:verbose]
@@ -60,12 +60,6 @@ module VagrantCloud
 
     def get_provider(provider_str)
       current_version.get_provider(provider_str)
-    end
-
-    def bump_version(version_str)
-      parts = version_str.split('.')
-      parts.push(parts.pop.to_i + 1)
-      parts.join('.')
     end
   end
 end

--- a/lib/vagrant_cloud/provider.rb
+++ b/lib/vagrant_cloud/provider.rb
@@ -25,17 +25,34 @@ module VagrantCloud
 
     # @return [Hash]
     def data
-      @data ||= account.request('get', "/box/#{account.username}/#{box.name}/version/#{version.number}/provider/#{name}")
+      @data ||= account.request('get', provider_path)
     end
 
     # @param [String] url
     def update(url)
       params = { url: url }
-      @data = account.request('put', "/box/#{account.username}/#{box.name}/version/#{version.number}/provider/#{name}", provider: params)
+      @data = account.request('put', provider_path, provider: params)
     end
 
     def delete
-      account.request('delete', "/box/#{account.username}/#{box.name}/version/#{version.number}/provider/#{name}")
+      account.request('delete', provider_path)
+    end
+
+    # @return [String]
+    def upload_url
+      account.request('get', "#{provider_path}/upload")['upload_path']
+    end
+
+    # @param [String] file_path
+    def upload_file(file_path)
+      url = upload_url
+      payload = File.read(file_path)
+      RestClient::Request.execute(
+        method: :put,
+        url: url,
+        payload: payload,
+        ssl_version: 'TLSv1'
+      )
     end
 
     private
@@ -48,6 +65,10 @@ module VagrantCloud
     # @return [Account]
     def account
       box.account
+    end
+
+    def provider_path
+      "/box/#{account.username}/#{box.name}/version/#{version.number}/provider/#{name}"
     end
   end
 end

--- a/lib/vagrant_cloud/version.rb
+++ b/lib/vagrant_cloud/version.rb
@@ -71,8 +71,8 @@ module VagrantCloud
     # @param [String] name
     # @param [String] url
     # @return [Provider]
-    def create_provider(name, url)
-      params = { name: name, url: url }
+    def create_provider(name, url = nil)
+      params = { name: name, url: url }.delete_if { |_k, v| v.nil? }
       data = account.request('post', "/box/#{account.username}/#{box.name}/version/#{number}/providers", provider: params)
       get_provider(name, data)
     end

--- a/spec/vagrant_cloud/cli_spec.rb
+++ b/spec/vagrant_cloud/cli_spec.rb
@@ -6,7 +6,7 @@ module VagrantCloud
     subject { described_class.start(argv) }
     let(:account) { double('account', get_box: box) }
     let(:box) { double('box', create_version: version, get_version: version, versions: [version]) }
-    let(:version) { double('version', version: version_number, status: 'unreleased', create_provider: provider, get_provider: provider, release: true ) }
+    let(:version) { double('version', version: version_number, status: 'unreleased', create_provider: provider, get_provider: provider, release: true) }
     let(:version_number) { '1.2.1' }
     let(:provider) { double('provider', upload_url: upload_url, upload_file: {}, data: provider_data) }
     let(:upload_url) { 'http://example.org/fake_upload_endpoint' }
@@ -51,7 +51,7 @@ module VagrantCloud
     describe '.create_provider' do
       let(:command) { 'create_provider' }
       let(:provider_url) { 'http://example.org/file.box' }
-      
+
       it { is_expected.to eq(provider) }
     end
 
@@ -70,7 +70,6 @@ module VagrantCloud
       end
 
       context 'when --provider_file_path not provided' do
-
         it 'uploads a file to an existing provider' do
           expect(provider).not_to receive(:upload_file)
           expect { subject }.to output(/No value provided for required options \'--provider-file-path\'/).to_stderr

--- a/spec/vagrant_cloud/cli_spec.rb
+++ b/spec/vagrant_cloud/cli_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+require 'vagrant_cloud'
+
+module VagrantCloud
+  describe Cli do
+    subject { described_class.start(argv) }
+    let(:account) { double('account', get_box: box) }
+    let(:box) { double('box', create_version: version, get_version: version, versions: [version]) }
+    let(:version) { double('version', version: version_number, status: 'unreleased', create_provider: provider, get_provider: provider) }
+    let(:version_number) { '1.2.1' }
+    let(:provider) { double('provider', upload_url: upload_url, upload_file: {}, data: provider_data) }
+    let(:upload_url) { 'http://example.org/fake_upload_endpoint' }
+    let(:provider_data) do
+      {
+        'name' => 'virtualbox'
+      }
+    end
+
+    let(:argv) do
+      [
+        command,
+        '--username',
+        'username',
+        '--token',
+        'token',
+        '--box',
+        'box',
+        '--version',
+        version_number,
+        '--no-verbose'
+      ]
+    end
+
+    before(:each) do
+      allow(VagrantCloud::Account).to receive(:new).and_return(account)
+    end
+
+    describe '.create_version' do
+      let(:command) { 'create_version' }
+      it { is_expected.to eq(version) }
+      it 'has the correct version number' do
+        expect(subject.version).to eq(version_number)
+      end
+    end
+
+    describe '.create_provider' do
+      let(:command) { 'create_provider' }
+      let(:provider_url) { 'http://example.org/file.box' }
+      let(:provider_file_path) { './example.box' }
+      it { is_expected.to eq(provider) }
+    end
+
+    describe '.versions' do
+      let(:command) { 'versions' }
+      it { is_expected.to eq([version]) }
+    end
+
+    describe '.upload_file' do
+      let(:command) { 'upload_file' }
+
+      before(:each) do
+        argv.push('--provider_file_path', './example.box')
+      end
+
+      it 'uploads a file to an existing provider' do
+        expect(provider).to receive(:upload_file)
+        subject
+      end
+    end
+  end
+end

--- a/spec/vagrant_cloud/cli_spec.rb
+++ b/spec/vagrant_cloud/cli_spec.rb
@@ -51,25 +51,30 @@ module VagrantCloud
     describe '.create_provider' do
       let(:command) { 'create_provider' }
       let(:provider_url) { 'http://example.org/file.box' }
-      let(:provider_file_path) { './example.box' }
+      
       it { is_expected.to eq(provider) }
-    end
-
-    describe '.versions' do
-      let(:command) { 'versions' }
-      it { is_expected.to eq([version]) }
     end
 
     describe '.upload_file' do
       let(:command) { 'upload_file' }
 
-      before(:each) do
-        argv.push('--provider_file_path', './example.box')
+      context 'when --provider_file_path provided' do
+        before(:each) do
+          argv.push('--provider_file_path', './example.box')
+        end
+
+        it 'uploads a file to an existing provider' do
+          expect(provider).to receive(:upload_file)
+          subject
+        end
       end
 
-      it 'uploads a file to an existing provider' do
-        expect(provider).to receive(:upload_file)
-        subject
+      context 'when --provider_file_path not provided' do
+
+        it 'uploads a file to an existing provider' do
+          expect(provider).not_to receive(:upload_file)
+          expect { subject }.to output(/No value provided for required options \'--provider-file-path\'/).to_stderr
+        end
       end
     end
   end

--- a/spec/vagrant_cloud/cli_spec.rb
+++ b/spec/vagrant_cloud/cli_spec.rb
@@ -43,6 +43,11 @@ module VagrantCloud
       end
     end
 
+    describe '.release_version' do
+      let(:command) { 'release_version' }
+      it { is_expected.to eq(true) }
+    end
+
     describe '.create_provider' do
       let(:command) { 'create_provider' }
       let(:provider_url) { 'http://example.org/file.box' }

--- a/spec/vagrant_cloud/cli_spec.rb
+++ b/spec/vagrant_cloud/cli_spec.rb
@@ -6,7 +6,7 @@ module VagrantCloud
     subject { described_class.start(argv) }
     let(:account) { double('account', get_box: box) }
     let(:box) { double('box', create_version: version, get_version: version, versions: [version]) }
-    let(:version) { double('version', version: version_number, status: 'unreleased', create_provider: provider, get_provider: provider) }
+    let(:version) { double('version', version: version_number, status: 'unreleased', create_provider: provider, get_provider: provider, release: true ) }
     let(:version_number) { '1.2.1' }
     let(:provider) { double('provider', upload_url: upload_url, upload_file: {}, data: provider_data) }
     let(:upload_url) { 'http://example.org/fake_upload_endpoint' }

--- a/spec/vagrant_cloud/version_spec.rb
+++ b/spec/vagrant_cloud/version_spec.rb
@@ -8,11 +8,7 @@ module VagrantCloud
 
     describe '#initialize' do
       it 'stores data' do
-        data = {
-          'version' => '1.2',
-          'description_markdown' => 'desc-markdown',
-          'status' => 'unreleased'
-        }
+        data = { 'version' => '1.2', 'description_markdown' => 'desc-markdown', 'status' => 'unreleased' }
         version = VagrantCloud::Version.new(box, '1.2', data)
 
         expect(version.box).to eq(box)
@@ -31,9 +27,7 @@ module VagrantCloud
         stub_request(:put, 'https://atlas.hashicorp.com/api/v1/box/my-acc/my-box/version/1.2').with(
           body: {
             access_token: 'my-token',
-            version: {
-              description: 'my-desc'
-            }
+            version: { description: 'my-desc' }
           }
         ).to_return(status: 200, body: JSON.dump(result))
 
@@ -85,22 +79,28 @@ module VagrantCloud
 
     describe '.create_provider' do
       it 'sends a POST request and returns the right instance' do
-        result = {
-          'foo' => 'foo'
-        }
+        result = { 'foo' => 'foo' }
         stub_request(:post, 'https://atlas.hashicorp.com/api/v1/box/my-acc/my-box/version/1.2/providers').with(
           body: {
             access_token: 'my-token',
-            provider: {
-              name: 'my-prov',
-              url: 'http://example.com'
-            }
+            provider: { name: 'my-prov', url: 'http://example.com' }
           }
         ).to_return(status: 200, body: JSON.dump(result))
 
         version = VagrantCloud::Version.new(box, '1.2')
         provider = version.create_provider('my-prov', 'http://example.com')
 
+        expect(provider).to be_a(Provider)
+        expect(provider.data).to eq(result)
+      end
+
+      it 'sends a POST request without a provider_url and creates an instance' do
+        result = { 'foo' => 'foo' }
+        stub_request(:post, 'https://atlas.hashicorp.com/api/v1/box/my-acc/my-box/version/1.2/providers').with(
+          body: { access_token: 'my-token', provider: { name: 'my-prov' } }
+        ).to_return(status: 200, body: JSON.dump(result))
+
+        provider = VagrantCloud::Version.new(box, '1.2').create_provider('my-prov')
         expect(provider).to be_a(Provider)
         expect(provider.data).to eq(result)
       end

--- a/vagrant_cloud.gemspec
+++ b/vagrant_cloud.gemspec
@@ -19,7 +19,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'webmock', '~> 3.0'
   s.add_development_dependency 'rubocop', '~> 0.41.2'
-  s.add_development_dependency 'pry'
-  s.add_development_dependency 'guard'
-  s.add_development_dependency 'guard-rspec'
 end

--- a/vagrant_cloud.gemspec
+++ b/vagrant_cloud.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'vagrant_cloud'
-  s.version     = '0.4.2'
+  s.version     = '0.5.0'
   s.summary     = 'HashiCorp Atlas API client'
   s.description = 'Minimalistic ruby client for the HashiCorp Atlas API (previously Vagrant Cloud API)'
   s.authors     = ['Cargo Media']
@@ -10,11 +10,16 @@ Gem::Specification.new do |s|
   }
   s.homepage    = 'https://github.com/cargomedia/vagrant_cloud'
   s.license     = 'MIT'
+  s.executables << 'vagrant_cloud'
 
-  s.add_runtime_dependency 'rest-client', '~>1.7'
+  s.add_runtime_dependency 'rest-client', '~> 1.7'
+  s.add_runtime_dependency 'thor', '~> 0.19.4'
 
   s.add_development_dependency 'rake', '~> 10.4'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'webmock', '~> 3.0'
   s.add_development_dependency 'rubocop', '~> 0.41.2'
+  s.add_development_dependency 'pry'
+  s.add_development_dependency 'guard'
+  s.add_development_dependency 'guard-rspec'
 end


### PR DESCRIPTION
two features:

1) Added ability to upload file to be hosted by Atlas.  The current implementation requires a URL to a remotely hosted file;  now the URL is optional and a file can be uploaded to Atlas

2) Added a CLI to improve shell scripting

Note:  rubocop was barking about the `version_spec.rb` file was too long, so I collapsed a few of the hashes.