### PR TITLE
Stream file uploads

### DIFF
--- a/lib/vagrant_cloud/provider.rb
+++ b/lib/vagrant_cloud/provider.rb
@@ -46,7 +46,7 @@ module VagrantCloud
     # @param [String] file_path
     def upload_file(file_path)
       url = upload_url
-      payload = File.read(file_path)
+      payload = File.open(file_path, 'r')
       RestClient::Request.execute(
         method: :put,
         url: url,


### PR DESCRIPTION
RestClient provider accepts objects that respond to `read` so that they can be streamed instead of loaded into memory.

This prevents OutOfMemory exceptions when trying to upload >4G files